### PR TITLE
Use a list or tuple for multiple-valued arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Usage examples:
 >>> cg.get_price(ids='bitcoin', vs_currencies='usd')
 {'bitcoin': {'usd': 3462.04}}
 
->>> cg.get_price(ids='bitcoin,litecoin,ethereum', vs_currencies='usd')
+>>> cg.get_price(ids=['bitcoin', 'litecoin', 'ethereum'], vs_currencies='usd')
 {'bitcoin': {'usd': 3461.27}, 'ethereum': {'usd': 106.92}, 'litecoin': {'usd': 32.72}}
 
->>> cg.get_price(ids='bitcoin,litecoin,ethereum', vs_currencies='usd,eur')
+>>> cg.get_price(ids=['bitcoin', 'litecoin', 'ethereum'], vs_currencies=['usd', 'eur'])
 {'bitcoin': {'usd': 3459.39, 'eur': 3019.33}, 'ethereum': {'usd': 106.91, 'eur': 93.31}, 'litecoin': {'usd': 32.72, 'eur': 28.56}}
 
 # optional parameteres can be passed as defined in the API doc (https://www.coingecko.com/api/docs/v3)
->>> cg.get_price(ids='bitcoin', vs_currencies='usd',include_market_cap='true',include_24hr_vol='true',include_24hr_change='true',include_last_updated_at='true')
+>>> cg.get_price(ids='bitcoin', vs_currencies='usd', include_market_cap='true', include_24hr_vol='true', include_24hr_change='true', include_last_updated_at='true')
 {'bitcoin': {'usd': 3458.74, 'usd_market_cap': 60574330199.29028, 'usd_24h_vol': 4182664683.6247883, 'usd_24h_change': 1.2295378479069035, 'last_updated_at': 1549071865}}
 ```
 

--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -4,6 +4,9 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
+from .utils import get_comma_separated_values
+
+
 class CoinGeckoAPI:
 
     __API_URL_BASE = 'https://api.coingecko.com/api/v3/'
@@ -49,12 +52,8 @@ class CoinGeckoAPI:
     def get_price(self, ids, vs_currencies, **kwargs):
         """Get the current price of any cryptocurrencies in any other supported currencies that you need"""
 
-        # remove empty spaces (when querying more than 1 coin, comma-separated,
-        # spaces may exist between coins ie ids='bitcoin, litecoin' -> ids='bitcoin,litecoin')
-        ids=ids.replace(' ','')
-        kwargs['ids'] = ids
-        vs_currencies=vs_currencies.replace(' ','')
-        kwargs['vs_currencies'] = vs_currencies
+        kwargs['ids'] = get_comma_separated_values(ids)
+        kwargs['vs_currencies'] = get_comma_separated_values(vs_currencies)
 
         api_url = '{0}simple/price'.format(self.api_base_url)
         api_url = self.__api_url_params(api_url, kwargs)
@@ -64,12 +63,8 @@ class CoinGeckoAPI:
     def get_token_price(self, id, contract_addresses, vs_currencies, **kwargs):
         """Get the current price of any tokens on this coin (ETH only at this stage as per api docs) in any other supported currencies that you need"""
 
-        # remove empty spaces (when querying more than 1 contact_address/currency, comma-separated,
-        # spaces may exist between addresses/currencies ie vs_currencies='eur, usd' -> ids='eur,usd')
-        contract_addresses=contract_addresses.replace(' ','')
-        kwargs['contract_addresses'] = contract_addresses
-        vs_currencies=vs_currencies.replace(' ','')
-        kwargs['vs_currencies'] = vs_currencies
+        kwargs['contract_addresses'] = get_comma_separated_values(contract_addresses)
+        kwargs['vs_currencies'] = get_comma_separated_values(vs_currencies)
 
         api_url = '{0}simple/token_price/{1}'.format(self.api_base_url, id)
         api_url = self.__api_url_params(api_url, kwargs)

--- a/pycoingecko/utils.py
+++ b/pycoingecko/utils.py
@@ -1,0 +1,7 @@
+def get_comma_separated_values(values):
+    """Return the values as a comma-separated string"""
+
+    # Make sure values is a list or tuple
+    if not isinstance(values, list) and not isinstance(values, tuple):
+        values = [values]
+    return ','.join(values)


### PR DESCRIPTION
I think it's easier to work with a list/tuple of values internally.

I also considered that it might be a bit tedious to use a list for single-valued params, so these two are both valid:

- `cg.get_price(ids="ethereum", **kwargs)`
- `cg.get_price(ids=["ethereum"], **kwargs)`