### PR TITLE
added check for json format in __request

### DIFF
--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -23,9 +23,12 @@ class CoinGeckoAPI:
         #print(url)
         try:
             response = self.session.get(url, timeout = self.request_timeout)
-            content = json.loads(response.content.decode('utf-8'))
-            response.raise_for_status()
-            return content
+
+            if "json" in response.headers.get('content-type'):
+                content = json.loads(response.content.decode('utf-8'))
+                response.raise_for_status()
+                return content
+                
         except Exception as e:
             try:
                 raise ValueError(content)


### PR DESCRIPTION
Coingecko returns an html string when something goes wrong in the request, which results in an error when json.loads is called on the html string. 
Returns None now if there is no json response.