### PR TITLE
Fix unbound local exception on GET request failure

### DIFF
--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -22,6 +22,10 @@ class CoinGeckoAPI:
         # print(url)
         try:
             response = self.session.get(url, timeout=self.request_timeout)
+        except requests.exceptions.RequestException:
+            raise
+
+        try:
             response.raise_for_status()
             content = json.loads(response.content.decode('utf-8'))
             return content
@@ -33,8 +37,7 @@ class CoinGeckoAPI:
             # if no json
             except json.decoder.JSONDecodeError:
                 pass
-            # except UnboundLocalError as e:
-            #    pass
+
             raise
 
     def __api_url_params(self, api_url, params):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+import requests.exceptions
 import responses
 import unittest
 import unittest.mock as mock
@@ -6,7 +7,13 @@ import unittest.mock as mock
 from pycoingecko import CoinGeckoAPI
 from requests.exceptions import HTTPError
 
+
 class TestWrapper(unittest.TestCase):
+
+    @responses.activate
+    def test_connection_error(self):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            CoinGeckoAPI().ping()
 
     @responses.activate
     def test_failed_ping(self):


### PR DESCRIPTION
This fix resolves unbound local errors when GET requests fail without returning a response (e.g. timeout).
By raising a Requests exception, external recovery logic that expects that can handle the error, e.g. retry the request.