### PR TITLE
Fix and a Feature: Retries

### DIFF
--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -16,7 +16,7 @@ class CoinGeckoAPI:
 
         self.session = requests.Session()
         retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[502, 503, 504])
-        self.session.mount('http://', HTTPAdapter(max_retries=retries))
+        self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
     def __request(self, url):
         # print(url)

--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -10,12 +10,12 @@ from .utils import func_args_preprocessing
 class CoinGeckoAPI:
     __API_URL_BASE = 'https://api.coingecko.com/api/v3/'
 
-    def __init__(self, api_base_url=__API_URL_BASE):
+    def __init__(self, api_base_url=__API_URL_BASE, retries=5):
         self.api_base_url = api_base_url
         self.request_timeout = 120
 
         self.session = requests.Session()
-        retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[502, 503, 504])
+        retries = Retry(total=retries, backoff_factor=0.5, status_forcelist=[502, 503, 504])
         self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
     def __request(self, url):


### PR DESCRIPTION
- Fixed session to mount retry adapter on https instead of http. Since CoinGecko API is https, we need to mount retry adapter on https, otherwise it doesn't work.
- Added the ability to change how many retries it does on the 502, 503 and 503 errors

Thanks for all the work on this client!