### PR TITLE
Adding API_KEY (x_cg_pro_api_key) support for https://pro-api.coingecko.com/api/v3 calls (pro version)

### DIFF
--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -51,8 +51,6 @@ class CoinGeckoAPI:
             # adding second '?' (api_url += '&' if '?' in api_url else '?'); causes
             # issues with request parametes (usually for endpoints with required
             # arguments passed as parameters)
-
-
             api_url += '&' if api_url_has_params else '?'
             for key, value in params.items():
                 if type(value) == bool:

--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -16,7 +16,6 @@ class CoinGeckoAPI:
         self.request_timeout = 120
 
         self.session = requests.Session()
-
         retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[502, 503, 504])
         self.session.mount('http://', HTTPAdapter(max_retries=retries))
 

--- a/pycoingecko/api.py
+++ b/pycoingecko/api.py
@@ -10,11 +10,13 @@ from .utils import func_args_preprocessing
 class CoinGeckoAPI:
     __API_URL_BASE = 'https://api.coingecko.com/api/v3/'
 
-    def __init__(self, api_base_url=__API_URL_BASE):
+    def __init__(self, api_base_url=__API_URL_BASE, api_key: str = ''):
         self.api_base_url = api_base_url
+        self.api_key = api_key
         self.request_timeout = 120
 
         self.session = requests.Session()
+
         retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[502, 503, 504])
         self.session.mount('http://', HTTPAdapter(max_retries=retries))
 
@@ -41,11 +43,17 @@ class CoinGeckoAPI:
             raise
 
     def __api_url_params(self, api_url, params, api_url_has_params=False):
+        # if using pro version of coingecko, inject key in every call
+        if len(self.api_key) > 0:
+            params['x_cg_pro_api_key'] = self.api_key
+
         if params:
             # if api_url contains already params and there is already a '?' avoid
             # adding second '?' (api_url += '&' if '?' in api_url else '?'); causes
             # issues with request parametes (usually for endpoints with required
             # arguments passed as parameters)
+
+
             api_url += '&' if api_url_has_params else '?'
             for key, value in params.items():
                 if type(value) == bool:


### PR DESCRIPTION
Add "x_cg_pro_api_key" to every call as this key is needed in coingecko pro version