### PR TITLE
Add Section to README for Extensions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,5 +260,15 @@ Run unit tests with:
 pytest tests
 ```
 
+## Extensions 
+
+If you are interested in an extended version of this api client that adds additional functionality like: 
+
+- Abstracting away complexities associated with server side rate limiting when sending many api requests. 
+- Page range queries. 
+- A roadmap for other future improvements. 
+
+Checkout [pycoingecko_extra](https://github.com/brycemorrow4564/pycoingecko-extra)!
+
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
Hi there! I'm the author of [pycoingecko_extra](https://github.com/brycemorrow4564/pycoingecko-extra) which is an extension of this base api client that adds a few new features like 

- Abstracting away complexities associated with server side rate limiting when sending many api requests. 
- Page range queries. 

I also have a few more future ideas of how to improve my extension of the client. My client extends the base class of this client and operates the exact same way, and the additional functionality is opt-in. Check out my README for more info.

I see my project as having a symbiotic relationship with the base client, as it merely extends instead of replacing the base api client. 

I was wondering if you would be willing to add an **Extensions** section to the README that links to my extension, so that users can discover it if they are interested in its feature set. 

I'd also be interested to hear if you would be willing to allow me to integrate this advanced feature set into the base client itself via a pull request. My design is a little more opinionated then the base client which is minimal, so I'd also be fine keeping the two as separate projects. 